### PR TITLE
[Frontend] feat: integrate Minhas Playlist with movies and add BDD tests

### DIFF
--- a/backend/cucumber-playlists.js
+++ b/backend/cucumber-playlists.js
@@ -1,0 +1,8 @@
+module.exports = {
+  default: {
+    paths: ["../features/gerenciar_playlists_servico.feature"],
+    requireModule: ["ts-node/register"],
+    require: ["tests/step_definitions/gerenciar_playlists_servico.steps.ts"],
+    format: ["progress"],
+  },
+};

--- a/backend/src/routes/playlist-route.ts
+++ b/backend/src/routes/playlist-route.ts
@@ -23,15 +23,6 @@ router.post("/playlists", postPlaylist);
 // O userId vem pela URL
 router.get("/users/:userId/playlists", getPlaylists);
 
-// Usado quando o usuário deseja editar o nome de uma playlist existente
-// O id da playlist vem pela URL
-// Body esperado: { name: string }
-router.patch("/playlists/:id", patchPlaylist);
-
-// Usado quando o usuário deseja excluir uma playlist existente
-// O id da playlist vem pela URL
-router.delete("/playlists/:id", deletePlaylist);
-
 // Usado quando o usuário deseja adicionar um filme a uma playlist
 // Body esperado: { userId: string, playlistName: string, movieName: string }
 router.post("/playlists/movies", postMovieToPlaylist);
@@ -40,3 +31,11 @@ router.post("/playlists/movies", postMovieToPlaylist);
 // Body esperado: { userId: string, playlistName: string, movieName: string }
 router.delete("/playlists/movies", deleteMovieFromPlaylist);
 
+// Usado quando o usuário deseja editar o nome de uma playlist existente
+// O id da playlist vem pela URL
+// Body esperado: { name: string }
+router.patch("/playlists/:id", patchPlaylist);
+
+// Usado quando o usuário deseja excluir uma playlist existente
+// O id da playlist vem pela URL
+router.delete("/playlists/:id", deletePlaylist);

--- a/backend/tests/step_definitions/gerenciar_playlists_servico.steps.ts
+++ b/backend/tests/step_definitions/gerenciar_playlists_servico.steps.ts
@@ -1,5 +1,4 @@
 import { After, AfterAll, Before, Given, Then, When } from "@cucumber/cucumber";
-import { strict as assert } from "assert";
 
 import { prisma } from "../../src/database/prisma";
 
@@ -15,9 +14,21 @@ import {
 import type { PlaylistModel } from "../../src/models/playlist-model";
 
 let currentUserId = "";
-let result: PlaylistModel[] | PlaylistModel | null = null;
+let result: PlaylistModel[] | PlaylistModel | string[] | null = null;
 let caughtError: Error | null = null;
 let requestedPlaylistName = "";
+
+const expectTrue = (condition: unknown, message: string): void => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const expectEqual = (actual: unknown, expected: unknown, message: string): void => {
+  if (actual !== expected) {
+    throw new Error(`${message}. Esperado: ${expected}. Recebido: ${actual}`);
+  }
+};
 
 const getUserId = (usuario: string): string => {
   return usuario;
@@ -30,6 +41,29 @@ const findPlaylist = async (usuario: string, playlistName: string) => {
       name: playlistName,
     },
   });
+};
+
+type PlaylistDatabaseRecord = NonNullable<
+  Awaited<ReturnType<typeof findPlaylist>>
+>;
+
+const requirePlaylist = (
+  playlist: PlaylistDatabaseRecord | null,
+  message: string,
+): PlaylistDatabaseRecord => {
+  if (!playlist) {
+    throw new Error(message);
+  }
+
+  return playlist;
+};
+
+const requireCaughtError = (): Error => {
+  if (!caughtError) {
+    throw new Error("Era esperado que uma exceção tivesse sido lançada");
+  }
+
+  return caughtError;
 };
 
 const createPlaylistDirectly = async (
@@ -116,15 +150,15 @@ Given(
 Given(
   "existe o filme {string} cadastrado no sistema",
   function (movieName: string) {
-    assert.ok(movieName.trim() !== "");
+    expectTrue(movieName.trim() !== "", "O nome do filme não pode ser vazio");
   },
 );
 
 Given(
   "existem os filmes {string} e {string} cadastrados no sistema",
   function (movie1: string, movie2: string) {
-    assert.ok(movie1.trim() !== "");
-    assert.ok(movie2.trim() !== "");
+    expectTrue(movie1.trim() !== "", "O nome do primeiro filme não pode ser vazio");
+    expectTrue(movie2.trim() !== "", "O nome do segundo filme não pode ser vazio");
   },
 );
 
@@ -133,9 +167,12 @@ Given(
   async function (playlistName: string, usuario: string, movieName: string) {
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
 
-    if (!playlist.movies.includes(movieName)) {
+    if (!existingPlaylist.movies.includes(movieName)) {
       await addMovieToPlaylistService({
         userId: usuario,
         playlistName,
@@ -150,9 +187,12 @@ Given(
   async function (playlistName: string, usuario: string, movieName: string) {
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
 
-    if (!playlist.movies.includes(movieName)) {
+    if (!existingPlaylist.movies.includes(movieName)) {
       await addMovieToPlaylistService({
         userId: usuario,
         playlistName,
@@ -220,13 +260,13 @@ When(
 
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(
+    const existingPlaylist = requirePlaylist(
       playlist,
-      'A playlist "' + playlistName + '" deveria existir antes da remoção',
+      `A playlist "${playlistName}" deveria existir antes da remoção`,
     );
 
     try {
-      await deletePlaylistService(playlist.id);
+      await deletePlaylistService(existingPlaylist.id);
 
       result = null;
       caughtError = null;
@@ -242,13 +282,13 @@ When(
   async function (usuario: string, oldName: string, newName: string) {
     const playlist = await findPlaylist(usuario, oldName);
 
-    assert.ok(
+    const existingPlaylist = requirePlaylist(
       playlist,
-      'A playlist "' + oldName + '" deveria existir antes da edição',
+      `A playlist "${oldName}" deveria existir antes da edição`,
     );
 
     try {
-      result = await updatePlaylistService(playlist.id, {
+      result = await updatePlaylistService(existingPlaylist.id, {
         name: newName,
       });
 
@@ -300,7 +340,7 @@ When(
   "o usuário {string} solicita as playlists disponíveis para adicionar o filme {string}",
   async function (usuario: string, _movieName: string) {
     try {
-      result = await getPlaylistsByUserIdService(usuario);
+      result = await getPlaylistsByUserIdService(getUserId(usuario));
       caughtError = null;
     } catch (error) {
       result = null;
@@ -312,55 +352,69 @@ When(
 Then(
   "o sistema retorna as playlists {string} e {string}",
   async function (playlist1: string, playlist2: string) {
-    assert.equal(caughtError, null);
-    assert.ok(Array.isArray(result));
+    expectEqual(caughtError, null, "Não deveria ter ocorrido erro");
+    expectTrue(Array.isArray(result), "O resultado deveria ser uma lista");
 
     const playlists = result as PlaylistModel[];
     const playlistNames = playlists.map((playlist) => playlist.name);
 
-    assert.ok(playlistNames.includes(playlist1));
-    assert.ok(playlistNames.includes(playlist2));
+    expectTrue(
+      playlistNames.includes(playlist1),
+      `A playlist "${playlist1}" deveria estar na lista`,
+    );
+    expectTrue(
+      playlistNames.includes(playlist2),
+      `A playlist "${playlist2}" deveria estar na lista`,
+    );
   },
 );
 
 Then("o sistema retorna uma lista vazia", function () {
-  assert.equal(caughtError, null);
-  assert.ok(Array.isArray(result));
+  expectEqual(caughtError, null, "Não deveria ter ocorrido erro");
+  expectTrue(Array.isArray(result), "O resultado deveria ser uma lista");
 
   const playlists = result as PlaylistModel[];
 
-  assert.equal(playlists.length, 0);
+  expectEqual(playlists.length, 0, "A lista deveria estar vazia");
 });
 
 Then(
   "o sistema cadastra a playlist {string} para o usuário {string}",
   async function (playlistName: string, usuario: string) {
-    assert.equal(caughtError, null);
+    expectEqual(caughtError, null, "Não deveria ter ocorrido erro");
 
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
-    assert.equal(playlist.name, playlistName);
-    assert.equal(playlist.userId, getUserId(usuario));
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
+
+    expectEqual(existingPlaylist.name, playlistName, "O nome da playlist deveria ser igual");
+    expectEqual(existingPlaylist.userId, getUserId(usuario), "O usuário dono da playlist deveria ser igual");
   },
 );
 
 Then(
   "a playlist {string} passa a pertencer ao usuário {string}",
   async function (playlistName: string, usuario: string) {
-    assert.equal(caughtError, null);
+    expectEqual(caughtError, null, "Não deveria ter ocorrido erro");
 
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
-    assert.equal(playlist.userId, getUserId(usuario));
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
+
+    expectEqual(existingPlaylist.userId, getUserId(usuario), "A playlist deveria pertencer ao usuário");
   },
 );
 
 Then(
   "o sistema não cadastra uma nova playlist para o usuário {string}",
   async function (usuario: string) {
-    assert.ok(caughtError);
+    requireCaughtError();
 
     const playlists = await prisma.playlist.findMany({
       where: {
@@ -369,39 +423,42 @@ Then(
       },
     });
 
-    assert.equal(playlists.length, 1);
+    expectEqual(playlists.length, 1, "Deveria existir apenas uma playlist com esse nome");
   },
 );
 
 Then(
   "o sistema informa que já existe uma playlist com esse nome para o usuário {string}",
   function (_usuario: string) {
-    assert.ok(caughtError);
-    assert.equal(caughtError.message, "Já existe uma playlist com esse nome");
+    const error = requireCaughtError();
+
+    expectEqual(error.message, "Já existe uma playlist com esse nome", "A mensagem de erro deveria ser a esperada");
   },
 );
 
 Then(
   "o sistema não cadastra a playlist para o usuário {string}",
   function (_usuario: string) {
-    assert.ok(caughtError);
-    assert.equal(result, null);
+    requireCaughtError();
+
+    expectEqual(result, null, "O resultado deveria ser nulo");
   },
 );
 
 Then("o sistema informa que o nome da playlist é obrigatório", function () {
-  assert.ok(caughtError);
-  assert.equal(caughtError.message, "O nome da playlist é obrigatório");
+  const error = requireCaughtError();
+
+  expectEqual(error.message, "O nome da playlist é obrigatório", "A mensagem de erro deveria ser a esperada");
 });
 
 Then(
   "o sistema remove a playlist {string} do usuário {string}",
   async function (playlistName: string, usuario: string) {
-    assert.equal(caughtError, null);
+    expectEqual(caughtError, null, "Não deveria ter ocorrido erro");
 
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.equal(playlist, null);
+    expectEqual(playlist, null, "A playlist deveria ter sido removida");
   },
 );
 
@@ -410,9 +467,13 @@ Then(
   async function (usuario: string, playlistName: string) {
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
-    assert.equal(playlist.name, playlistName);
-    assert.equal(playlist.userId, getUserId(usuario));
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
+
+    expectEqual(existingPlaylist.name, playlistName, "O nome da playlist deveria continuar igual");
+    expectEqual(existingPlaylist.userId, getUserId(usuario), "O usuário dono da playlist deveria continuar igual");
   },
 );
 
@@ -421,27 +482,31 @@ Then(
   async function (usuario: string, playlistName: string) {
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.equal(playlist, null);
+    expectEqual(playlist, null, "A playlist deveria ter sido removida");
   },
 );
 
 Then(
   "o sistema altera o nome da playlist para {string} para o usuário {string}",
   async function (playlistName: string, usuario: string) {
-    assert.equal(caughtError, null);
+    expectEqual(caughtError, null, "Não deveria ter ocorrido erro");
 
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
-    assert.equal(playlist.name, playlistName);
-    assert.equal(playlist.userId, getUserId(usuario));
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
+
+    expectEqual(existingPlaylist.name, playlistName, "O nome da playlist deveria ter sido atualizado");
+    expectEqual(existingPlaylist.userId, getUserId(usuario), "O usuário dono da playlist deveria continuar igual");
   },
 );
 
 Then(
   "o sistema não altera o nome da playlist {string}",
   async function (playlistName: string) {
-    assert.ok(caughtError);
+    requireCaughtError();
 
     const playlist = await prisma.playlist.findFirst({
       where: {
@@ -450,20 +515,31 @@ Then(
       },
     });
 
-    assert.ok(playlist);
-    assert.equal(playlist.name, playlistName);
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria continuar existindo`,
+    );
+
+    expectEqual(existingPlaylist.name, playlistName, "O nome da playlist deveria permanecer igual");
   },
 );
 
 Then(
   "o sistema adiciona o filme {string} à playlist {string} do usuário {string}",
   async function (movieName: string, playlistName: string, usuario: string) {
-    assert.equal(caughtError, null);
+    expectEqual(caughtError, null, "Não deveria ter ocorrido erro");
 
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
-    assert.ok(playlist.movies.includes(movieName));
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
+
+    expectTrue(
+      existingPlaylist.movies.includes(movieName),
+      `O filme "${movieName}" deveria estar na playlist`,
+    );
   },
 );
 
@@ -472,23 +548,35 @@ Then(
   async function (movieName: string, playlistName: string, usuario: string) {
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
-    assert.ok(!playlist.movies.includes(movieName));
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
+
+    expectTrue(
+      !existingPlaylist.movies.includes(movieName),
+      `O filme "${movieName}" não deveria estar na playlist`,
+    );
   },
 );
 
 Then(
   "o sistema não adiciona novamente o filme {string} à playlist {string} do usuário {string}",
   async function (movieName: string, playlistName: string, usuario: string) {
-    assert.ok(caughtError);
+    requireCaughtError();
 
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
 
-    const occurrences = playlist.movies.filter((movie) => movie === movieName);
+    const occurrences = existingPlaylist.movies.filter(
+      (movie) => movie === movieName,
+    );
 
-    assert.equal(occurrences.length, 1);
+    expectEqual(occurrences.length, 1, "O filme deveria aparecer apenas uma vez");
   },
 );
 
@@ -497,28 +585,41 @@ Then(
   async function (playlistName: string, usuario: string, movieName: string) {
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
 
-    const occurrences = playlist.movies.filter((movie) => movie === movieName);
+    const occurrences = existingPlaylist.movies.filter(
+      (movie) => movie === movieName,
+    );
 
-    assert.equal(occurrences.length, 1);
+    expectEqual(occurrences.length, 1, "O filme deveria aparecer apenas uma vez");
   },
 );
 
 Then("o sistema informa que o filme já está na playlist", function () {
-  assert.ok(caughtError);
-  assert.equal(caughtError.message, "Filme já está na playlist");
+  const error = requireCaughtError();
+
+  expectEqual(error.message, "Filme já está na playlist", "A mensagem de erro deveria ser a esperada");
 });
 
 Then(
   "o sistema remove o filme {string} da playlist {string} do usuário {string}",
   async function (movieName: string, playlistName: string, usuario: string) {
-    assert.equal(caughtError, null);
+    expectEqual(caughtError, null, "Não deveria ter ocorrido erro");
 
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
-    assert.ok(!playlist.movies.includes(movieName));
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
+
+    expectTrue(
+      !existingPlaylist.movies.includes(movieName),
+      `O filme "${movieName}" deveria ter sido removido`,
+    );
   },
 );
 
@@ -527,8 +628,15 @@ Then(
   async function (playlistName: string, usuario: string, movieName: string) {
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
-    assert.ok(!playlist.movies.includes(movieName));
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
+
+    expectTrue(
+      !existingPlaylist.movies.includes(movieName),
+      `O filme "${movieName}" não deveria estar mais na playlist`,
+    );
   },
 );
 
@@ -537,39 +645,135 @@ Then(
   async function (playlistName: string, usuario: string, movieName: string) {
     const playlist = await findPlaylist(usuario, playlistName);
 
-    assert.ok(playlist);
-    assert.ok(playlist.movies.includes(movieName));
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
+
+    expectTrue(
+      existingPlaylist.movies.includes(movieName),
+      `O filme "${movieName}" deveria continuar na playlist`,
+    );
   },
 );
 
 Then("o sistema retorna uma lista vazia de playlists disponíveis", function () {
-  assert.equal(caughtError, null);
-  assert.ok(Array.isArray(result));
+  expectEqual(caughtError, null, "Não deveria ter ocorrido erro");
+  expectTrue(Array.isArray(result), "O resultado deveria ser uma lista");
 
   const playlists = result as PlaylistModel[];
 
-  assert.equal(playlists.length, 0);
+  expectEqual(playlists.length, 0, "A lista deveria estar vazia");
 });
 
 Then(
   "o sistema não adiciona o filme {string} a nenhuma playlist do usuário {string}",
   async function (movieName: string, usuario: string) {
-    const playlists = await getPlaylistsByUserIdService(usuario);
+    const playlists = await getPlaylistsByUserIdService(getUserId(usuario));
 
     const playlistWithMovie = playlists.find((playlist) =>
       playlist.movies.includes(movieName),
     );
 
-    assert.equal(playlistWithMovie, undefined);
+    expectEqual(playlistWithMovie, undefined, "Nenhuma playlist deveria conter o filme");
   },
 );
 
 Then("o sistema informa que não existem playlists disponíveis", function () {
-  assert.equal(caughtError, null);
-  assert.ok(Array.isArray(result));
+  expectEqual(caughtError, null, "Não deveria ter ocorrido erro");
+  expectTrue(Array.isArray(result), "O resultado deveria ser uma lista");
 
   const playlists = result as PlaylistModel[];
 
-  assert.equal(playlists.length, 0);
+  expectEqual(playlists.length, 0, "A lista deveria estar vazia");
 });
 
+Given(
+  "a playlist {string} contém os filmes {string} e {string}",
+  async function (playlistName: string, movie1: string, movie2: string) {
+    const usuario = currentUserId;
+
+    const playlist = await findPlaylist(usuario, playlistName);
+
+    requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
+
+    await addMovieToPlaylistService({
+      userId: usuario,
+      playlistName,
+      movieName: movie1,
+    });
+
+    await addMovieToPlaylistService({
+      userId: usuario,
+      playlistName,
+      movieName: movie2,
+    });
+  },
+);
+
+Given(
+  "a playlist {string} não possui filmes adicionados",
+  async function (playlistName: string) {
+    const usuario = currentUserId;
+
+    const playlist = await findPlaylist(usuario, playlistName);
+
+    const existingPlaylist = requirePlaylist(
+      playlist,
+      `A playlist "${playlistName}" deveria existir`,
+    );
+
+    for (const movieName of existingPlaylist.movies) {
+      await removeMovieFromPlaylistService({
+        userId: usuario,
+        playlistName,
+        movieName,
+      });
+    }
+  },
+);
+
+When(
+  "o usuário {string} entra na página {string}",
+  async function (_usuario: string, playlistName: string) {
+    const usuario = currentUserId;
+
+    try {
+      const playlist = await findPlaylist(usuario, playlistName);
+
+      const existingPlaylist = requirePlaylist(
+        playlist,
+        `A playlist "${playlistName}" deveria existir`,
+      );
+
+      result = existingPlaylist.movies;
+      caughtError = null;
+    } catch (error) {
+      result = null;
+      caughtError = error as Error;
+    }
+  },
+);
+
+Then(
+  "o sistema exibe os filmes {string} e {string}",
+  function (movie1: string, movie2: string) {
+    expectEqual(caughtError, null, "Não deveria ter ocorrido erro");
+    expectTrue(Array.isArray(result), "O resultado deveria ser uma lista");
+
+    const movies = result as string[];
+
+    expectTrue(
+      movies.includes(movie1),
+      `O filme "${movie1}" deveria ser exibido`,
+    );
+
+    expectTrue(
+      movies.includes(movie2),
+      `O filme "${movie2}" deveria ser exibido`,
+    );
+  },
+);

--- a/frontend/src/pages/MinhasPlaylists/MinhasPlaylistsPage.css
+++ b/frontend/src/pages/MinhasPlaylists/MinhasPlaylistsPage.css
@@ -66,11 +66,20 @@
 }
 
 .playlist-logo {
-  padding: 42px 32px;
-  color: var(--cinema-primary);
-  font-family: Manrope, sans-serif;
-  font-size: 22px;
-  font-weight: 800;
+  border: 0;
+  background: transparent;
+  padding: 24px 24px 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.playlist-logo img {
+  width: 220px;
+  max-width: 100%;
+  height: auto;
+  display: block;
 }
 
 .playlist-menu {
@@ -601,6 +610,10 @@
 
   .playlist-logo {
     padding: 24px 20px;
+  }
+
+  .playlist-logo img {
+    width: 180px;
   }
 
   .playlist-menu {

--- a/frontend/src/pages/MinhasPlaylists/MinhasPlaylistsPage.tsx
+++ b/frontend/src/pages/MinhasPlaylists/MinhasPlaylistsPage.tsx
@@ -8,6 +8,7 @@ import {
   removeMovieFromPlaylist,
   updatePlaylist,
 } from "../../services/playlistApi";
+import cinemaLogo from "../../assets/cinema_logo.png";
 import "./MinhasPlaylistsPage.css";
 
 interface MinhasPlaylistsPageProps {
@@ -37,37 +38,37 @@ export function MinhasPlaylistsPage({
 
   const hasPlaylists = playlists.length > 0;
 
-  async function loadPlaylists() {
-    try {
-      setLoading(true);
-
-      const data = await getPlaylistsByUserId(userId);
-
-      setPlaylists(data.playlists);
-
-      if (data.playlists.length === 0) {
-        setMessage({
-          type: "info",
-          text: "Ainda não existem playlists criadas",
-        });
-      } else {
-        setMessage(null);
-      }
-    } catch (error) {
-      setMessage({
-        type: "error",
-        text:
-          error instanceof Error
-            ? error.message
-            : "Erro inesperado ao buscar playlists",
-      });
-    } finally {
-      setLoading(false);
-    }
-  }
-
   useEffect(() => {
-    loadPlaylists();
+    async function loadPlaylists() {
+      try {
+        setLoading(true);
+
+        const data = await getPlaylistsByUserId(userId);
+
+        setPlaylists(data.playlists);
+
+        if (data.playlists.length === 0) {
+          setMessage({
+            type: "info",
+            text: "Ainda não existem playlists criadas",
+          });
+        } else {
+          setMessage(null);
+        }
+      } catch (error) {
+        setMessage({
+          type: "error",
+          text:
+            error instanceof Error
+              ? error.message
+              : "Erro inesperado ao buscar playlists",
+        });
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    void loadPlaylists();
   }, [userId]);
 
   function openCreateModal() {
@@ -125,7 +126,10 @@ export function MinhasPlaylistsPage({
           userId,
         });
 
-        setPlaylists((currentPlaylists) => [data.playlist, ...currentPlaylists]);
+        setPlaylists((currentPlaylists) => [
+          data.playlist,
+          ...currentPlaylists,
+        ]);
 
         setMessage({
           type: "success",
@@ -212,7 +216,14 @@ export function MinhasPlaylistsPage({
   return (
     <div className="playlist-shell">
       <aside className="playlist-sidebar">
-        <div className="playlist-logo">Cinema</div>
+        <button
+          className="playlist-logo"
+          type="button"
+          onClick={onGoToHome}
+          aria-label="Ir para a página principal"
+        >
+          <img src={cinemaLogo} alt="CInema Filmes Antigos" />
+        </button>
 
         <nav className="playlist-menu">
           <button

--- a/frontend/tests/step_definitions/gerenciar-playlists-gui-steps.ts
+++ b/frontend/tests/step_definitions/gerenciar-playlists-gui-steps.ts
@@ -1,0 +1,871 @@
+import { Before, Given, Then, When } from "@cucumber/cucumber";
+
+type MessageType = "success" | "error" | "info";
+
+interface PlaylistState {
+  name: string;
+  movies: string[];
+}
+
+interface MessageState {
+  type: MessageType;
+  text: string;
+}
+
+interface TestState {
+  userName: string | null;
+  currentPage: string | null;
+  selectedPlaylist: string | null;
+  availablePages: Set<string>;
+  playlists: Map<string, PlaylistState>;
+  visiblePlaylists: string[];
+  visiblePlaylistMovies: string[];
+  catalogMovies: Set<string>;
+  availablePlaylistsToAddMovie: string[];
+  message: MessageState | null;
+  lastActionSuccess: boolean | null;
+  lastActionType: string | null;
+  playlistCountBeforeAction: number;
+}
+
+function expectTrue(condition: boolean, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function expectEqual<T>(actual: T, expected: T, message: string) {
+  if (actual !== expected) {
+    throw new Error(`${message}. Esperado: ${expected}. Recebido: ${actual}`);
+  }
+}
+
+function expectDefined<T>(
+  value: T | null | undefined,
+  message: string,
+): asserts value is T {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
+}
+
+function createInitialState(): TestState {
+  return {
+    userName: null,
+    currentPage: null,
+    selectedPlaylist: null,
+    availablePages: new Set<string>(),
+    playlists: new Map<string, PlaylistState>(),
+    visiblePlaylists: [],
+    visiblePlaylistMovies: [],
+    catalogMovies: new Set<string>(),
+    availablePlaylistsToAddMovie: [],
+    message: null,
+    lastActionSuccess: null,
+    lastActionType: null,
+    playlistCountBeforeAction: 0,
+  };
+}
+
+let state: TestState = createInitialState();
+
+function resetState() {
+  state = createInitialState();
+}
+
+function renderMinhasPlaylistsPage() {
+  state.currentPage = "Minhas Playlists";
+  state.selectedPlaylist = null;
+  state.visiblePlaylists = Array.from(state.playlists.keys());
+  state.visiblePlaylistMovies = [];
+
+  if (state.visiblePlaylists.length === 0) {
+    state.message = {
+      type: "info",
+      text: "Ainda não existem playlists criadas",
+    };
+  }
+}
+
+function renderPlaylistDetail(playlistName: string) {
+  const playlist = state.playlists.get(playlistName);
+
+  state.currentPage = "Minhas Playlists";
+  state.selectedPlaylist = playlistName;
+  state.visiblePlaylists = Array.from(state.playlists.keys());
+  state.visiblePlaylistMovies = playlist ? [...playlist.movies] : [];
+}
+
+function ensurePlaylistExists(playlistName: string) {
+  if (!state.playlists.has(playlistName)) {
+    state.playlists.set(playlistName, {
+      name: playlistName,
+      movies: [],
+    });
+  }
+}
+
+function removePlaylistIfExists(playlistName: string) {
+  state.playlists.delete(playlistName);
+  state.visiblePlaylists = state.visiblePlaylists.filter(
+    (name) => name !== playlistName,
+  );
+}
+
+function getPlaylist(playlistName: string) {
+  return state.playlists.get(playlistName);
+}
+
+function countPlaylistOccurrences(playlistName: string) {
+  return Array.from(state.playlists.keys()).filter(
+    (name) => name === playlistName,
+  ).length;
+}
+
+function countMovieOccurrences(playlistName: string, movieName: string) {
+  const playlist = getPlaylist(playlistName);
+
+  if (!playlist) {
+    return 0;
+  }
+
+  return playlist.movies.filter((movie) => movie === movieName).length;
+}
+
+function createPlaylist(playlistName: string) {
+  state.playlistCountBeforeAction = state.playlists.size;
+  state.lastActionType = "create";
+
+  const trimmedName = playlistName.trim();
+
+  if (!trimmedName) {
+    state.lastActionSuccess = false;
+    state.message = {
+      type: "error",
+      text: "O nome da playlist é obrigatório",
+    };
+    return;
+  }
+
+  if (state.playlists.has(trimmedName)) {
+    state.lastActionSuccess = false;
+    state.message = {
+      type: "error",
+      text: "Já existe uma playlist com esse nome",
+    };
+    return;
+  }
+
+  state.playlists.set(trimmedName, {
+    name: trimmedName,
+    movies: [],
+  });
+
+  state.lastActionSuccess = true;
+  state.message = {
+    type: "success",
+    text: "Playlist criada com sucesso",
+  };
+
+  if (state.currentPage === "Minhas Playlists") {
+    renderMinhasPlaylistsPage();
+    state.message = {
+      type: "success",
+      text: "Playlist criada com sucesso",
+    };
+  }
+}
+
+function editPlaylist(oldName: string, newName: string) {
+  state.lastActionType = "edit";
+
+  const oldPlaylist = getPlaylist(oldName);
+
+  if (!oldPlaylist) {
+    state.lastActionSuccess = false;
+    state.message = {
+      type: "error",
+      text: "Playlist não encontrada",
+    };
+    return;
+  }
+
+  if (state.playlists.has(newName)) {
+    state.lastActionSuccess = false;
+    state.message = {
+      type: "error",
+      text: "Já existe uma playlist com esse nome",
+    };
+    return;
+  }
+
+  state.playlists.delete(oldName);
+  state.playlists.set(newName, {
+    name: newName,
+    movies: [...oldPlaylist.movies],
+  });
+
+  state.lastActionSuccess = true;
+  state.message = {
+    type: "success",
+    text: "Playlist atualizada com sucesso",
+  };
+
+  if (state.currentPage === "Minhas Playlists") {
+    renderMinhasPlaylistsPage();
+    state.message = {
+      type: "success",
+      text: "Playlist atualizada com sucesso",
+    };
+  }
+}
+
+function deletePlaylist(playlistName: string) {
+  state.lastActionType = "delete-playlist";
+
+  if (!state.playlists.has(playlistName)) {
+    state.lastActionSuccess = false;
+    state.message = {
+      type: "error",
+      text: "Playlist não encontrada",
+    };
+    return;
+  }
+
+  state.playlists.delete(playlistName);
+
+  state.lastActionSuccess = true;
+  state.message = {
+    type: "success",
+    text: "Playlist removida com sucesso",
+  };
+
+  if (state.currentPage === "Minhas Playlists") {
+    renderMinhasPlaylistsPage();
+    state.message = {
+      type: "success",
+      text: "Playlist removida com sucesso",
+    };
+  }
+}
+
+function addMovieToPlaylist(movieName: string, playlistName: string) {
+  state.lastActionType = "add-movie";
+
+  const playlist = getPlaylist(playlistName);
+
+  if (!playlist) {
+    state.lastActionSuccess = false;
+    state.message = {
+      type: "error",
+      text: "Playlist não encontrada",
+    };
+    return;
+  }
+
+  if (playlist.movies.includes(movieName)) {
+    state.lastActionSuccess = false;
+    state.message = {
+      type: "error",
+      text: "Filme já está na playlist",
+    };
+    return;
+  }
+
+  playlist.movies.push(movieName);
+
+  state.lastActionSuccess = true;
+  state.message = {
+    type: "success",
+    text: "Filme adicionado à playlist com sucesso",
+  };
+}
+
+function removeMovieFromPlaylist(movieName: string, playlistName: string) {
+  state.lastActionType = "remove-movie";
+
+  const playlist = getPlaylist(playlistName);
+
+  if (!playlist) {
+    state.lastActionSuccess = false;
+    state.message = {
+      type: "error",
+      text: "Playlist não encontrada",
+    };
+    return;
+  }
+
+  if (!playlist.movies.includes(movieName)) {
+    state.lastActionSuccess = false;
+    state.message = {
+      type: "error",
+      text: "Filme não encontrado na playlist",
+    };
+    return;
+  }
+
+  playlist.movies = playlist.movies.filter((movie) => movie !== movieName);
+
+  state.lastActionSuccess = true;
+  state.message = {
+    type: "success",
+    text: "Filme removido da playlist com sucesso",
+  };
+
+  if (state.selectedPlaylist === playlistName) {
+    renderPlaylistDetail(playlistName);
+    state.message = {
+      type: "success",
+      text: "Filme removido da playlist com sucesso",
+    };
+  }
+}
+
+Before(function () {
+  resetState();
+});
+
+Given("eu acesso o sistema como {string}", function (userName: string) {
+  state.userName = userName;
+});
+
+Given("a página {string} está disponível", function (pageName: string) {
+  state.availablePages.add(pageName);
+});
+
+Given(
+  "eu possuo as playlists {string} e {string}",
+  function (playlistName1: string, playlistName2: string) {
+    ensurePlaylistExists(playlistName1);
+    ensurePlaylistExists(playlistName2);
+  },
+);
+
+Given("eu não possuo playlists criadas", function () {
+  state.playlists.clear();
+  state.visiblePlaylists = [];
+});
+
+Given("eu estou na página {string}", function (pageName: string) {
+  state.currentPage = pageName;
+
+  if (pageName === "Minhas Playlists") {
+    renderMinhasPlaylistsPage();
+  }
+});
+
+Given("eu não possuo a playlist {string}", function (playlistName: string) {
+  removePlaylistIfExists(playlistName);
+});
+
+Given("existe a opção de criar playlists", function () {
+  expectEqual(
+    state.currentPage,
+    "Minhas Playlists",
+    "A opção de criar playlists só deve existir na página Minhas Playlists",
+  );
+});
+
+Given("eu possuo a playlist {string}", function (playlistName: string) {
+  ensurePlaylistExists(playlistName);
+
+  if (state.currentPage === "Minhas Playlists") {
+    renderMinhasPlaylistsPage();
+  }
+});
+
+Given(
+  "existe a opção de remover a playlist {string}",
+  function (playlistName: string) {
+    expectTrue(
+      state.playlists.has(playlistName),
+      `A playlist "${playlistName}" deveria existir para ser removida`,
+    );
+  },
+);
+
+Given(
+  "existe a opção de editar a playlist {string}",
+  function (playlistName: string) {
+    expectTrue(
+      state.playlists.has(playlistName),
+      `A playlist "${playlistName}" deveria existir para ser editada`,
+    );
+  },
+);
+
+Given("eu vejo o filme {string}", function (movieName: string) {
+  state.catalogMovies.add(movieName);
+});
+
+Given(
+  "o filme {string} possui a opção de ser adicionado a uma playlist",
+  function (movieName: string) {
+    expectTrue(
+      state.catalogMovies.has(movieName),
+      `O filme "${movieName}" deveria estar visível no catálogo`,
+    );
+  },
+);
+
+Given(
+  "a playlist {string} já possui o filme {string}",
+  function (playlistName: string, movieName: string) {
+    ensurePlaylistExists(playlistName);
+
+    const playlist = getPlaylist(playlistName);
+    expectDefined(playlist, `A playlist "${playlistName}" deveria existir`);
+
+    if (!playlist.movies.includes(movieName)) {
+      playlist.movies.push(movieName);
+    }
+  },
+);
+
+Given("eu estou na playlist {string}", function (playlistName: string) {
+  ensurePlaylistExists(playlistName);
+  renderPlaylistDetail(playlistName);
+});
+
+Given(
+  "a playlist {string} possui o filme {string}",
+  function (playlistName: string, movieName: string) {
+    ensurePlaylistExists(playlistName);
+
+    const playlist = getPlaylist(playlistName);
+    expectDefined(playlist, `A playlist "${playlistName}" deveria existir`);
+
+    if (!playlist.movies.includes(movieName)) {
+      playlist.movies.push(movieName);
+    }
+
+    if (state.selectedPlaylist === playlistName) {
+      renderPlaylistDetail(playlistName);
+    }
+  },
+);
+
+Given(
+  "o filme {string} possui a opção de ser removido da playlist {string}",
+  function (movieName: string, playlistName: string) {
+    const playlist = getPlaylist(playlistName);
+    expectDefined(playlist, `A playlist "${playlistName}" deveria existir`);
+
+    expectTrue(
+      playlist.movies.includes(movieName),
+      `O filme "${movieName}" deveria estar na playlist "${playlistName}"`,
+    );
+  },
+);
+
+When("eu acesso a página {string}", function (pageName: string) {
+  expectTrue(
+    state.availablePages.has(pageName) || pageName === "Minhas Playlists",
+    `A página "${pageName}" deveria estar disponível`,
+  );
+
+  if (pageName === "Minhas Playlists") {
+    renderMinhasPlaylistsPage();
+    return;
+  }
+
+  state.currentPage = pageName;
+});
+
+When("eu tento criar a playlist {string}", function (playlistName: string) {
+  createPlaylist(playlistName);
+});
+
+When("eu tento criar uma playlist sem informar nome", function () {
+  createPlaylist("");
+});
+
+When("eu tento remover a playlist {string}", function (playlistName: string) {
+  deletePlaylist(playlistName);
+});
+
+When(
+  "eu tento mudar o nome da playlist {string} para {string}",
+  function (oldName: string, newName: string) {
+    editPlaylist(oldName, newName);
+  },
+);
+
+When(
+  "eu tento adicionar o filme {string} à playlist {string}",
+  function (movieName: string, playlistName: string) {
+    addMovieToPlaylist(movieName, playlistName);
+  },
+);
+
+When(
+  "eu tento remover o filme {string} da playlist {string}",
+  function (movieName: string, playlistName: string) {
+    removeMovieFromPlaylist(movieName, playlistName);
+  },
+);
+
+When(
+  "eu clico na opção de adicionar o filme {string} a uma playlist",
+  function (movieName: string) {
+    state.lastActionType = "open-add-movie-modal";
+
+    if (state.playlists.size === 0) {
+      state.availablePlaylistsToAddMovie = [];
+      state.lastActionSuccess = false;
+      state.message = {
+        type: "info",
+        text: "Não existem playlists disponíveis",
+      };
+      return;
+    }
+
+    state.availablePlaylistsToAddMovie = Array.from(state.playlists.keys());
+    state.lastActionSuccess = true;
+    state.message = null;
+    state.catalogMovies.add(movieName);
+  },
+);
+
+Then(
+  "as playlists {string} e {string} são exibidas",
+  function (playlistName1: string, playlistName2: string) {
+    expectTrue(
+      state.visiblePlaylists.includes(playlistName1),
+      `A playlist "${playlistName1}" deveria estar visível`,
+    );
+
+    expectTrue(
+      state.visiblePlaylists.includes(playlistName2),
+      `A playlist "${playlistName2}" deveria estar visível`,
+    );
+  },
+);
+
+Then("nenhuma playlist é exibida", function () {
+  expectEqual(
+    state.visiblePlaylists.length,
+    0,
+    "Nenhuma playlist deveria estar visível",
+  );
+});
+
+Then("o sistema informa que ainda não existem playlists criadas", function () {
+  expectEqual(state.message?.type, "info", "A mensagem deveria ser informativa");
+
+  const text = state.message?.text.toLowerCase() ?? "";
+
+  expectTrue(
+    text.includes("não existem playlists") ||
+      text.includes("ainda não existem playlists"),
+    "A mensagem deveria informar que ainda não existem playlists criadas",
+  );
+});
+
+Then("o sistema cria a playlist {string}", function (playlistName: string) {
+  expectEqual(state.lastActionType, "create", "A última ação deveria ser criar");
+  expectEqual(state.lastActionSuccess, true, "A criação deveria ter sucesso");
+
+  expectTrue(
+    state.playlists.has(playlistName),
+    `A playlist "${playlistName}" deveria ter sido criada`,
+  );
+});
+
+Then(
+  "a playlist {string} aparece na página {string}",
+  function (playlistName: string, pageName: string) {
+    expectEqual(
+      pageName,
+      "Minhas Playlists",
+      "A verificação deveria ocorrer na página Minhas Playlists",
+    );
+
+    expectTrue(
+      state.visiblePlaylists.includes(playlistName),
+      `A playlist "${playlistName}" deveria aparecer na página`,
+    );
+  },
+);
+
+Then("o sistema exibe uma mensagem de sucesso", function () {
+  expectEqual(state.message?.type, "success", "A mensagem deveria ser de sucesso");
+});
+
+Then("o sistema não cria uma nova playlist", function () {
+  expectEqual(state.lastActionType, "create", "A última ação deveria ser criar");
+  expectEqual(state.lastActionSuccess, false, "A criação deveria falhar");
+});
+
+Then(
+  "a playlist {string} permanece aparecendo uma única vez na página {string}",
+  function (playlistName: string, pageName: string) {
+    expectEqual(
+      pageName,
+      "Minhas Playlists",
+      "A verificação deveria ocorrer na página Minhas Playlists",
+    );
+
+    if (state.currentPage === "Minhas Playlists") {
+      renderMinhasPlaylistsPage();
+    }
+
+    expectEqual(
+      countPlaylistOccurrences(playlistName),
+      1,
+      `A playlist "${playlistName}" deveria existir uma única vez no estado`,
+    );
+
+    expectEqual(
+      state.visiblePlaylists.filter((name) => name === playlistName).length,
+      1,
+      `A playlist "${playlistName}" deveria aparecer uma única vez na tela`,
+    );
+  },
+);
+
+Then("o sistema exibe uma mensagem de erro", function () {
+  expectEqual(state.message?.type, "error", "A mensagem deveria ser de erro");
+});
+
+Then("o sistema não cria a playlist", function () {
+  expectEqual(state.lastActionType, "create", "A última ação deveria ser criar");
+  expectEqual(state.lastActionSuccess, false, "A criação deveria falhar");
+});
+
+Then("nenhuma nova playlist aparece na página {string}", function (pageName: string) {
+  expectEqual(
+    pageName,
+    "Minhas Playlists",
+    "A verificação deveria ocorrer na página Minhas Playlists",
+  );
+
+  expectEqual(
+    state.playlists.size,
+    state.playlistCountBeforeAction,
+    "Nenhuma nova playlist deveria ter sido criada",
+  );
+});
+
+Then("o sistema remove a playlist {string}", function (playlistName: string) {
+  expectEqual(
+    state.lastActionType,
+    "delete-playlist",
+    "A última ação deveria ser remover playlist",
+  );
+
+  expectEqual(state.lastActionSuccess, true, "A remoção deveria ter sucesso");
+
+  expectTrue(
+    !state.playlists.has(playlistName),
+    `A playlist "${playlistName}" deveria ter sido removida`,
+  );
+});
+
+Then(
+  "a playlist {string} não aparece na página {string}",
+  function (playlistName: string, pageName: string) {
+    expectEqual(
+      pageName,
+      "Minhas Playlists",
+      "A verificação deveria ocorrer na página Minhas Playlists",
+    );
+
+    if (state.currentPage === "Minhas Playlists") {
+      renderMinhasPlaylistsPage();
+    }
+
+    expectTrue(
+      !state.visiblePlaylists.includes(playlistName),
+      `A playlist "${playlistName}" não deveria aparecer na página`,
+    );
+  },
+);
+
+Then(
+  "a playlist {string} permanece aparecendo na página {string}",
+  function (playlistName: string, pageName: string) {
+    expectEqual(
+      pageName,
+      "Minhas Playlists",
+      "A verificação deveria ocorrer na página Minhas Playlists",
+    );
+
+    if (state.currentPage === "Minhas Playlists") {
+      renderMinhasPlaylistsPage();
+    }
+
+    expectTrue(
+      state.visiblePlaylists.includes(playlistName),
+      `A playlist "${playlistName}" deveria permanecer aparecendo`,
+    );
+  },
+);
+
+Then(
+  "o sistema altera o nome da playlist para {string}",
+  function (newPlaylistName: string) {
+    expectEqual(state.lastActionType, "edit", "A última ação deveria ser editar");
+    expectEqual(state.lastActionSuccess, true, "A edição deveria ter sucesso");
+
+    expectTrue(
+      state.playlists.has(newPlaylistName),
+      `A playlist "${newPlaylistName}" deveria existir após a edição`,
+    );
+  },
+);
+
+Then(
+  "o sistema não altera o nome da playlist {string}",
+  function (playlistName: string) {
+    expectEqual(state.lastActionType, "edit", "A última ação deveria ser editar");
+    expectEqual(state.lastActionSuccess, false, "A edição deveria falhar");
+
+    expectTrue(
+      state.playlists.has(playlistName),
+      `A playlist "${playlistName}" deveria continuar existindo`,
+    );
+  },
+);
+
+Then(
+  "o sistema adiciona o filme {string} à playlist {string}",
+  function (movieName: string, playlistName: string) {
+    const playlist = getPlaylist(playlistName);
+    expectDefined(playlist, `A playlist "${playlistName}" deveria existir`);
+
+    expectEqual(
+      state.lastActionType,
+      "add-movie",
+      "A última ação deveria ser adicionar filme",
+    );
+
+    expectEqual(state.lastActionSuccess, true, "A adição deveria ter sucesso");
+
+    expectTrue(
+      playlist.movies.includes(movieName),
+      `O filme "${movieName}" deveria estar na playlist "${playlistName}"`,
+    );
+  },
+);
+
+Then(
+  "o sistema não adiciona o filme {string} à playlist {string}",
+  function (movieName: string, playlistName: string) {
+    const playlist = getPlaylist(playlistName);
+    expectDefined(playlist, `A playlist "${playlistName}" deveria existir`);
+
+    expectTrue(
+      !playlist.movies.includes(movieName),
+      `O filme "${movieName}" não deveria estar na playlist "${playlistName}"`,
+    );
+  },
+);
+
+Then(
+  "o sistema não adiciona novamente o filme {string} à playlist {string}",
+  function (movieName: string, playlistName: string) {
+    expectEqual(
+      state.lastActionType,
+      "add-movie",
+      "A última ação deveria ser adicionar filme",
+    );
+
+    expectEqual(state.lastActionSuccess, false, "A adição deveria falhar");
+
+    expectEqual(
+      countMovieOccurrences(playlistName, movieName),
+      1,
+      `O filme "${movieName}" deveria aparecer apenas uma vez na playlist "${playlistName}"`,
+    );
+  },
+);
+
+Then(
+  "a playlist {string} mantém apenas uma ocorrência do filme {string}",
+  function (playlistName: string, movieName: string) {
+    expectEqual(
+      countMovieOccurrences(playlistName, movieName),
+      1,
+      `A playlist "${playlistName}" deveria manter apenas uma ocorrência do filme "${movieName}"`,
+    );
+  },
+);
+
+Then(
+  "o sistema remove o filme {string} da playlist {string}",
+  function (movieName: string, playlistName: string) {
+    expectEqual(
+      state.lastActionType,
+      "remove-movie",
+      "A última ação deveria ser remover filme",
+    );
+
+    expectEqual(state.lastActionSuccess, true, "A remoção deveria ter sucesso");
+
+    expectEqual(
+      countMovieOccurrences(playlistName, movieName),
+      0,
+      `O filme "${movieName}" deveria ter sido removido da playlist "${playlistName}"`,
+    );
+  },
+);
+
+Then(
+  "a playlist {string} não exibe o filme {string}",
+  function (playlistName: string, movieName: string) {
+    if (state.selectedPlaylist === playlistName) {
+      renderPlaylistDetail(playlistName);
+    }
+
+    expectTrue(
+      !state.visiblePlaylistMovies.includes(movieName),
+      `A playlist "${playlistName}" não deveria exibir o filme "${movieName}"`,
+    );
+  },
+);
+
+Then(
+  "a playlist {string} continua exibindo o filme {string}",
+  function (playlistName: string, movieName: string) {
+    if (state.selectedPlaylist === playlistName) {
+      renderPlaylistDetail(playlistName);
+    }
+
+    expectTrue(
+      state.visiblePlaylistMovies.includes(movieName),
+      `A playlist "${playlistName}" deveria continuar exibindo o filme "${movieName}"`,
+    );
+  },
+);
+
+Then("o sistema não exibe playlists disponíveis", function () {
+  expectEqual(
+    state.availablePlaylistsToAddMovie.length,
+    0,
+    "Nenhuma playlist deveria estar disponível para adicionar filme",
+  );
+});
+
+Then(
+  "o sistema não adiciona o filme {string} a nenhuma playlist",
+  function (movieName: string) {
+    const playlists = Array.from(state.playlists.values());
+
+    expectTrue(
+      playlists.every((playlist) => !playlist.movies.includes(movieName)),
+      `O filme "${movieName}" não deveria ter sido adicionado a nenhuma playlist`,
+    );
+  },
+);
+
+Then("o sistema informa que não existem playlists disponíveis", function () {
+  expectEqual(state.message?.type, "info", "A mensagem deveria ser informativa");
+
+  const text = state.message?.text.toLowerCase() ?? "";
+
+  expectTrue(
+    text.includes("não existem playlists disponíveis"),
+    "A mensagem deveria informar que não existem playlists disponíveis",
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
       "license": "ISC",
       "devDependencies": {
         "@cucumber/cucumber": "^12.8.2",
-        "concurrently": "^9.2.1"
+        "@types/node": "^25.9.2",
+        "concurrently": "^9.2.1",
+        "ts-node": "^10.9.2",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -47,6 +50,19 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@cucumber/ci-environment": {
@@ -277,6 +293,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@teppeis/multimaps": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-3.0.0.tgz",
@@ -287,12 +331,76 @@
         "node": ">=14"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "4.1.1",
@@ -321,6 +429,13 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
     },
@@ -516,6 +631,13 @@
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -841,6 +963,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/mime": {
       "version": "3.0.0",
@@ -1382,6 +1511,50 @@
         "node": ">=6.10"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1401,6 +1574,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.4.0",
@@ -1429,6 +1623,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/util-arity/-/util-arity-1.1.0.tgz",
       "integrity": "sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1540,6 +1741,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yup": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "license": "ISC",
   "devDependencies": {
     "@cucumber/cucumber": "^12.8.2",
-    "concurrently": "^9.2.1"
+    "@types/node": "^25.9.2",
+    "concurrently": "^9.2.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## O que foi feito

* Implementa a tela de **Minhas Playlists** no frontend.
* Integra a página de playlists com os serviços da API.
* Permite criar, visualizar, editar e remover playlists.
* Permite visualizar filmes dentro de uma playlist.
* Permite remover filmes de uma playlist.
* Ajusta a ordem das rotas de playlists no backend para evitar conflito entre `/playlists/:id` e `/playlists/movies`.
* Adiciona a logo do CInema na página de Minhas Playlists.
* Adiciona testes BDD da interface de playlists.
* Ajusta e valida os testes BDD de serviço da feature de playlists.

## Testes realizados

Foram executados os testes BDD da feature de playlists no frontend e no backend.

### Testes de GUI

```bash
NODE_OPTIONS="--loader ts-node/esm" npx cucumber-js features/gerenciar_playlists_gui.feature --import frontend/tests/step_definitions/gerenciar-playlists-gui-steps.ts
```

### Testes de serviço

```bash
cd backend
unset NODE_OPTIONS
TS_NODE_TRANSPILE_ONLY=true TS_NODE_COMPILER_OPTIONS='{"module":"CommonJS","moduleResolution":"node","ignoreDeprecations":"6.0"}' npx cucumber-js --config cucumber-playlists.js
```

## Observações

A integração ainda utiliza o `userId` recebido pelas páginas a partir do `App.tsx`. Quando a feature de login estiver integrada ao frontend, o usuário fixo poderá ser substituído pelo usuário autenticado real sem alterar a lógica interna da página de playlists.
